### PR TITLE
Add Dockerfile for PHP 7.2

### DIFF
--- a/Dockerfile.php71
+++ b/Dockerfile.php71
@@ -21,24 +21,25 @@ RUN add-apt-repository -y \
 
 # Install PHP-CLI 7, some PHP extentions and some useful Tools with APT
 RUN apt-get update && apt-get install -y --force-yes \
-        php7.2-cli \
-        php7.2-common \
-        php7.2-curl \
-        php7.2-json \
-        php7.2-xml \
-        php7.2-mbstring \
-        php7.2-mysql \
-        php7.2-pgsql \
-        php7.2-sqlite \
-        php7.2-sqlite3 \
-        php7.2-zip \
-        php7.2-memcached \
-        php7.2-gd \
-        php7.2-fpm \
-        php7.2-xdebug \
-        php7.2-bcmath \
-        php7.2-intl \
-        php7.2-dev \
+        php7.1-cli \
+        php7.1-common \
+        php7.1-curl \
+        php7.1-json \
+        php7.1-xml \
+        php7.1-mbstring \
+        php7.1-mcrypt \
+        php7.1-mysql \
+        php7.1-pgsql \
+        php7.1-sqlite \
+        php7.1-sqlite3 \
+        php7.1-zip \
+        php7.1-memcached \
+        php7.1-gd \
+        php7.1-fpm \
+        php7.1-xdebug \
+        php7.1-bcmath \
+        php7.1-intl \
+        php7.1-dev \
         libcurl4-openssl-dev \
         libedit-dev \
         libssl-dev \
@@ -55,22 +56,22 @@ RUN apt-get update && apt-get install -y --force-yes \
         iputils-ping
 
 # remove load xdebug extension (only load on phpunit command)
-# RUN sed -i 's/^/;/g' /etc/php/7.2/cli/conf.d/20-xdebug.ini
-
-# Load xdebug Zend extension with phpunit command
-# RUN echo "alias phpunit='php -dzend_extension=xdebug.so /var/www/laravel/vendor/bin/phpunit'" >> ~/.bashrc
+RUN sed -i 's/^/;/g' /etc/php/7.1/cli/conf.d/20-xdebug.ini
 
 # Add bin folder of composer to PATH.
 RUN echo "export PATH=${PATH}:/var/www/laravel/vendor/bin:/root/.composer/vendor/bin" >> ~/.bashrc
 
+# Load xdebug Zend extension with phpunit command
+RUN echo "alias phpunit='php -dzend_extension=xdebug.so /var/www/laravel/vendor/bin/phpunit'" >> ~/.bashrc
+
 # Install mongodb extension
 RUN pecl channel-update pecl.php.net && pecl install mongodb
-RUN echo "extension=mongodb.so" >> /etc/php/7.2/cli/php.ini
+RUN echo "extension=mongodb.so" >> /etc/php/7.1/cli/php.ini
 
 # Install Nodejs
-RUN curl -sL https://deb.nodesource.com/setup_10.x | bash - \
+RUN curl -sL https://deb.nodesource.com/setup_8.x | bash - \
     && apt-get install -y nodejs \
-    && npm install -g eslint babel-eslint eslint-plugin-react yarn
+    && npm install -g gulp-cli bower eslint babel-eslint eslint-plugin-react yarn
 
 # Install SASS
 RUN apt-get install -y ruby ruby-dev \
@@ -96,7 +97,7 @@ RUN ln -s /root/.composer/vendor/bin/phpcs /usr/bin/phpcs \
     && ln -s /root/.composer/vendor/bin/phpcpd /usr/bin/phpcpd
 
 # Install framgia-ci-tool
-RUN curl -o /usr/bin/framgia-ci https://raw.githubusercontent.com/framgiaci/framgia-ci-cli/master/dist/framgia-ci \
+RUN curl -o /usr/bin/framgia-ci https://raw.githubusercontent.com/framgia/ci-report-tool/master/dist/framgia-ci \
     && chmod +x /usr/bin/framgia-ci
 
 # Clean up


### PR DESCRIPTION
- Prepare for Laravel 6
- Remove `mcrypt` because it was removed in PHP 7.2
- Enable `xdebug` by default
- Update to Node 10 LTS
- Update Framgia CI V3 Tool